### PR TITLE
add write-stream transctions and implicit rollback

### DIFF
--- a/schema.proto
+++ b/schema.proto
@@ -8,6 +8,13 @@ enum CONTENT {
   FILE = 2;
 }
 
+enum COMMIT_TYPE {
+  DATA = 1;
+  TRANSACTION_START = 2;
+  TRANSACTION_DATA = 3;
+  TRANSACTION_END = 4;
+}
+
 message Operation {
   optional CONTENT content = 5;
   required TYPE type = 1;
@@ -22,6 +29,7 @@ message File {
 }
 
 message Commit {
+  optional COMMIT_TYPE type = 3 [default = DATA];
   optional uint64 modified = 2;
   repeated Operation operations = 1;
 }


### PR DESCRIPTION
This PR adds write stream transactions if you set `{transaction: true}` in the write stream method.

``` js
var ws = dat.createWriteStream({transaction: true})
// wraps everything in a transaction block (start-->data-->data-->..-->end)
ws.write('hello')
ws.write('hello')
ws.end()
```

To see if you are currently in the middle of a transaction use the status api

``` js
dat.status(function (err, status) {
  console.log('in a transaction?', status.transaction)
})
```

And to rollback to where the transaction started simply do a checkout

``` js
var anotherDat = dat.checkout()
// anotherDat is guaranteed to not be in a transaction
```

Feedback appreciated :)
