### PR TITLE
default dataset to 'files' for file write stream and listDatasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 tmp
 sandbox.js
+test/data.dat

--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ Dat.prototype.listDatasets = function (cb) {
           var dataset = keys[0].split('!')[3]
           if (!dataset) return cb(null, result)
 
-          result.push(dataset)
+          if (dataset !== 'files') result.push(dataset)
           loop(dataset)
         })
       }
@@ -325,6 +325,7 @@ Dat.prototype.createFileReadStream = function (key, opts) {
 
 Dat.prototype.createFileWriteStream = function (key, opts) {
   if (!opts) opts = {}
+  if (!opts.dataset) opts.dataset = 'files'
 
   var stream = duplexify()
 

--- a/test/dataset.js
+++ b/test/dataset.js
@@ -1,0 +1,39 @@
+var dat = require('../')
+var tape = require('tape')
+var collect = require('stream-collector')
+var memdb = require('memdb')
+
+var create = function () {
+  return dat(memdb(), {valueEncoding: 'utf-8'})
+}
+
+tape('opens', function (t) {
+  var db = create()
+
+  db.on('ready', function () {
+    t.ok(true, 'ready')
+    t.end()
+  })
+})
+
+tape('write to dataset', function (t) {
+  var db = create()
+
+  var ws = db.createWriteStream({batchSize: 2, dataset: 'test'})
+
+  ws.write({key: 'a', value: 'a'})
+  ws.write({key: 'b', value: 'b'})
+  ws.write({key: 'c', value: 'c'})
+
+  ws.end(function () {
+    collect(db.createKeyStream({dataset: 'no-exist'}), function (err, list) {
+      t.error(err, 'no err')
+      t.same(list, [])
+      collect(db.createKeyStream({dataset: 'test'}), function (err, list) {
+        t.error(err, 'no err')
+        t.same(list, ['a', 'b', 'c'])
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
I want to fix a small bug where `dat datasets` shows the `files` dataset while `dat status` doesn’t count the `files` dataset. Since people are starting to build on dat using js, I figure it’d be good to normalize this api a bit.

With this change, if user1 builds a dat with the js api using fileWriteStream, it’ll default to the `files` dataset — user2 can still `dat clone` and be able to `dat read` as though user1 added it with the cli.
