### PR TITLE
adhere to padded-blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,7 +261,6 @@ Dat.prototype.listDatasets = function (cb) {
       }
 
       loop(null)
-
     }
 
     var loop = function (err) {

--- a/lib/indexer.js
+++ b/lib/indexer.js
@@ -242,7 +242,6 @@ var Indexer = function (opts, cb) {
       if (self.multiprocess.follower) return done()
       self.multiprocess.once('follower', done)
     })
-
   }
 
   this.mainLayer = null


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.
